### PR TITLE
[gdk-pixbuf] Remove obsolete x11 configure option. JB#57204

### DIFF
--- a/rpm/gdk-pixbuf.spec
+++ b/rpm/gdk-pixbuf.spec
@@ -53,8 +53,7 @@ the functionality of the installed %{name} package.
 %build
 %meson -Dbuiltin_loaders=png \
        -Ddocs=false \
-       -Dman=false \
-       -Dx11=false
+       -Dman=false
 
 %global _smp_mflags -j1
 %meson_build


### PR DESCRIPTION
Fixes build with new meson.